### PR TITLE
Allow authentication with only jsessionId.

### DIFF
--- a/src/DeGiro.ts
+++ b/src/DeGiro.ts
@@ -68,8 +68,8 @@ export class DeGiro implements DeGiroClassInterface {
 
   /* Properties */
 
-  private readonly username: string
-  private readonly pwd: string
+  private readonly username: string | undefined
+  private readonly pwd: string | undefined
   private readonly oneTimePassword: string | undefined
   private jsessionId: string | undefined
   private accountConfig: AccountConfigType | undefined
@@ -85,8 +85,8 @@ export class DeGiro implements DeGiroClassInterface {
     oneTimePassword = oneTimePassword || process.env['DEGIRO_OTP']
     jsessionId = jsessionId || process.env['DEGIRO_JSESSIONID']
 
-    if (!username) throw new Error('DeGiro api needs an username to access')
-    if (!pwd) throw new Error('DeGiro api needs an password to access')
+    if (!username && !jsessionId) throw new Error('DeGiro api needs an username to access')
+    if (!pwd && !jsessionId) throw new Error('DeGiro api needs an password to access')
 
     this.username = username
     this.pwd = pwd
@@ -105,8 +105,8 @@ export class DeGiro implements DeGiroClassInterface {
     if (this.jsessionId) return this.loginWithJSESSIONID(this.jsessionId)
     return new Promise((resolve, reject) => {
       loginRequest({
-        username: this.username,
-        pwd: this.pwd,
+        username: this.username as string,
+        pwd: this.pwd as string,
         oneTimePassword: this.oneTimePassword,
       })
         .then((loginResponse: LoginResponseType) => {

--- a/src/api/getAccountConfig.ts
+++ b/src/api/getAccountConfig.ts
@@ -30,7 +30,10 @@ export function getAccountConfigRequest(sessionId: string): Promise<AccountConfi
     // Do the request to get a account config data
     debug(`Making request to ${BASE_API_URL}${GET_ACCOUNT_CONFIG_PATH} with JSESSIONID: ${sessionId}`)
     fetch(BASE_API_URL + GET_ACCOUNT_CONFIG_PATH, requestOptions)
-      .then(res => res.json())
+      .then( res => {
+        if (!res.ok) { reject(res.statusText) }
+        return res.json()
+      })
       .then((res: AccountConfigType) => {
         debug('Response:\n', JSON.stringify(res, null, 2))
         resolve(res)


### PR DESCRIPTION
As the title says. The program always demands a username and pwd for a login(). But this is not necessary when jsessionId is supplied. The PR makes username and pwd optional if jsessionId is defined.

Cheers!