### PR TITLE
Make all fetch requests use requestOptions from single util file.

### DIFF
--- a/src/api/createOrderRequest.ts
+++ b/src/api/createOrderRequest.ts
@@ -6,28 +6,12 @@ import { DEGIRO_API_PATHS } from '../enums'
 const { CREATE_ORDER_PATH } = DEGIRO_API_PATHS
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function createOrderRequest(order: OrderType, accountData: AccountDataType, accountConfig: AccountConfigType): Promise<CreateOrderResultType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      body: JSON.stringify(order),
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId, 'POST', JSON.stringify(order), 'application/json;charset=UTF-8')
 
     const uri = `${accountConfig.data.tradingUrl}${CREATE_ORDER_PATH};jsessionid=${accountConfig.data.sessionId}?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`
     debug(uri, requestOptions)

--- a/src/api/deleteOrderRequest.ts
+++ b/src/api/deleteOrderRequest.ts
@@ -2,28 +2,12 @@
 import { AccountDataType, AccountConfigType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function deleteOrderRequest(orderId: String, accountData: AccountDataType, accountConfig: AccountConfigType): Promise<void> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      body: '',
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId, 'DELETE', '', 'application/json;charset=UTF-8')
 
     // tslint:disable-next-line: max-line-length
     const uri = `https://trader.degiro.nl/trading/secure/v5/order/${orderId};jsessionid=${accountConfig.data.sessionId}?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`

--- a/src/api/executeOrderRequest.ts
+++ b/src/api/executeOrderRequest.ts
@@ -2,28 +2,12 @@
 import { OrderType, AccountDataType, AccountConfigType, CreateOrderResultType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function executeOrderRequest(order: OrderType, executeId: String, accountData: AccountDataType, accountConfig: AccountConfigType): Promise<String> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      body: JSON.stringify(order),
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId, 'POST', JSON.stringify(order), 'application/json;charset=UTF-8')
 
     // tslint:disable-next-line: max-line-length
     const uri = `https://trader.degiro.nl/trading/secure/v5/order/${executeId};jsessionid=${accountConfig.data.sessionId}?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`

--- a/src/api/getAccountConfig.ts
+++ b/src/api/getAccountConfig.ts
@@ -16,7 +16,7 @@ export function getAccountConfigRequest(sessionId: string): Promise<AccountConfi
     // Do the request to get a account config data
     debug(`Making request to ${BASE_API_URL}${GET_ACCOUNT_CONFIG_PATH} with JSESSIONID: ${sessionId}`)
     fetch(BASE_API_URL + GET_ACCOUNT_CONFIG_PATH, requestOptions)
-      .then( res => {
+      .then((res) => {
         if (!res.ok) { reject(res.statusText) }
         return res.json()
       })

--- a/src/api/getAccountConfig.ts
+++ b/src/api/getAccountConfig.ts
@@ -6,26 +6,12 @@ import { DEGIRO_API_PATHS } from '../enums'
 const { BASE_API_URL, GET_ACCOUNT_CONFIG_PATH } = DEGIRO_API_PATHS
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function getAccountConfigRequest(sessionId: string): Promise<AccountConfigType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(sessionId)
 
     // Do the request to get a account config data
     debug(`Making request to ${BASE_API_URL}${GET_ACCOUNT_CONFIG_PATH} with JSESSIONID: ${sessionId}`)

--- a/src/api/getAccountData.ts
+++ b/src/api/getAccountData.ts
@@ -2,26 +2,12 @@
 import { AccountDataType, AccountConfigType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function getAccountDataRequest(accountConfig: AccountConfigType): Promise<AccountDataType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     debug(`Making request to ${accountConfig.data.paUrl}client?sessionId=${accountConfig.data.sessionId}`)

--- a/src/api/getAccountInfoRequest.ts
+++ b/src/api/getAccountInfoRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, AccountInfoType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 // Importamos constantes
 import { DEGIRO_API_PATHS } from '../enums'
@@ -11,21 +11,7 @@ const { GET_ACCOUNT_INFO_PATH } = DEGIRO_API_PATHS
 export function getAccountInfoRequest(accountData: AccountDataType, accountConfig: AccountConfigType): Promise<AccountInfoType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.tradingUrl}${GET_ACCOUNT_INFO_PATH}${accountData.data.intAccount};jsessionid=${accountConfig.data.sessionId}`

--- a/src/api/getAccountReportsRequest.ts
+++ b/src/api/getAccountReportsRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, AccountReportsType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 // Import utils functions
 import { generateReportURIFromID } from '../utils/generateReportURIFromID'
@@ -14,21 +14,7 @@ const { GET_ACCOUNT_REPORTS_PATH } = DEGIRO_API_PATHS
 export function getAccountReportsRequest(accountData: AccountDataType, accountConfig: AccountConfigType): Promise<AccountReportsType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.paUrl}${GET_ACCOUNT_REPORTS_PATH}?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`

--- a/src/api/getAccountStateRequest.ts
+++ b/src/api/getAccountStateRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, GetAccountStateOptionsType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 import { DEGIRO_API_PATHS } from '../enums/DeGiroEnums'
 const { GET_ACCOUNT_STATE_PATH } = DEGIRO_API_PATHS
 
@@ -17,21 +17,7 @@ export function getAccountStateRequest(accountData: AccountDataType, accountConf
     params += `intAccount=${accountData.data.intAccount}&`
     params += `sessionId=${accountConfig.data.sessionId}`
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.reportingUrl}${GET_ACCOUNT_STATE_PATH}?${params}`

--- a/src/api/getCashFundstRequest.ts
+++ b/src/api/getCashFundstRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, CashFoundType } from '../types'
 
 // Import debug console log
-import { debug, processGetCashFundsResultListObject } from '../utils'
+import { debug, processGetCashFundsResultListObject, getFetchRequestOptions } from '../utils'
 import { DEGIRO_API_PATHS } from '../enums/DeGiroEnums'
 const { GET_GENERIC_DATA_PATH } = DEGIRO_API_PATHS
 
@@ -14,21 +14,7 @@ export function getCashFundstRequest(accountData: AccountDataType, accountConfig
     params += 'cashFunds=0&'
     params += 'limit=100'
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.tradingUrl}${GET_GENERIC_DATA_PATH}${accountData.data.intAccount};jsessionid=${accountConfig.data.sessionId}?${params}`

--- a/src/api/getConfigDictionaryRequest.ts
+++ b/src/api/getConfigDictionaryRequest.ts
@@ -2,26 +2,12 @@
 import { AccountConfigType, AccountDataType, ConfigDictionaryType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function getConfigDictionaryRequest(accountData: AccountDataType, accountConfig: AccountConfigType): Promise<ConfigDictionaryType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.dictionaryUrl}?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`

--- a/src/api/getNewsRequest.ts
+++ b/src/api/getNewsRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, i18nMessagesType, GetNewsOptionsType, NewsType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 // Import paths
 import { DEGIRO_API_PATHS } from '../enums'
@@ -21,21 +21,7 @@ export function getNewsRequest(options: GetNewsOptionsType, accountData: Account
     params += `sessionId=${accountConfig.data.sessionId}`
 
     // Generate Request options
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Generate de request URIs
     const latestNewsURI = `${accountConfig.data.companiesServiceUrl}${GET_LATESTS_NEWS_PATH}?${params}`

--- a/src/api/getOrdersRequest.ts
+++ b/src/api/getOrdersRequest.ts
@@ -4,7 +4,7 @@ import { AccountConfigType, AccountDataType, GetOrdersConfigType, GetOrdersResul
 // Import debug console log
 import { debug } from '../utils'
 import { GET_ORDERS_TYPES } from '../enums/DeGiroEnums'
-import { processGetOrdersResultListObject } from '../utils/'
+import { processGetOrdersResultListObject, getFetchRequestOptions } from '../utils/'
 
 // tslint:disable-next-line: max-line-length
 export function getOrdersRequest(accountData: AccountDataType, accountConfig: AccountConfigType, config: GetOrdersConfigType): Promise<GetOrdersResultType> {
@@ -15,16 +15,7 @@ export function getOrdersRequest(accountData: AccountDataType, accountConfig: Ac
     if (active) params += `${GET_ORDERS_TYPES.ACTIVE}=0&`
     if (lastTransactions) params += `${GET_ORDERS_TYPES.TRANSACTIONS}=0&`
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers?: any,
-      credentials: 'include',
-      referer: string,
-    } = {
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.tradingUrl}v5/update/${accountData.data.intAccount};jsessionid=${accountConfig.data.sessionId}?${params}`

--- a/src/api/getPopularStocksRequest.ts
+++ b/src/api/getPopularStocksRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, StockType, GetPopularStocksConfigType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 // Importamos constantes
 import { DEGIRO_API_PATHS } from '../enums'
@@ -13,21 +13,7 @@ export function getPopularStocksRequest(accountData: AccountDataType, accountCon
   return new Promise((resolve, reject) => {
 
     // Create fetch request options
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Create params to reach popular stocks
     const { popularOnly = true, requireTotal = false, limit = 9, offset = 0 } = config

--- a/src/api/getPortfolioRequest.ts
+++ b/src/api/getPortfolioRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, GetPorfolioConfigType } from '../types'
 
 // Import debug console log
-import { debug, processPortfolio } from '../utils'
+import { debug, processPortfolio, getFetchRequestOptions } from '../utils'
 
 // tslint:disable-next-line: max-line-length
 export function getPortfolioRequest(accountData: AccountDataType, accountConfig: AccountConfigType, config: GetPorfolioConfigType): Promise<any[]> {
@@ -11,8 +11,10 @@ export function getPortfolioRequest(accountData: AccountDataType, accountConfig:
     const params = '&portfolio=0'
 
     // Do the request to get a account config data
-    debug(`Making request to ${accountConfig.data.tradingUrl}v5/update/${accountData.data.intAccount};jsessionid=${accountConfig.data.sessionId}?${params}}`)
-    fetch(`${accountConfig.data.tradingUrl}v5/update/${accountData.data.intAccount};jsessionid=${accountConfig.data.sessionId}?${params}`)
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
+    const uri = `${accountConfig.data.tradingUrl}v5/update/${accountData.data.intAccount};jsessionid=${accountConfig.data.sessionId}?${params}`
+    debug(`Making request to ${uri}`)
+    fetch(uri, requestOptions)
       .then(res => res.json())
       .then((res) => {
         const portfolio: any[] = res.portfolio.value

--- a/src/api/getProductsByIdsRequest.ts
+++ b/src/api/getProductsByIdsRequest.ts
@@ -2,29 +2,15 @@
 import { AccountConfigType, AccountDataType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 // tslint:disable-next-line: max-line-length
 export function getProductsByIdsRequest(ids: string[], accountData: AccountDataType, accountConfig: AccountConfigType): Promise<any[]> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      method: 'POST',
-      body: JSON.stringify(ids.map(id => id.toString())),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    // tslint:disable-next-line: max-line-length
+    const body = JSON.stringify(ids.map(id => id.toString()))
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId, 'POST', body, 'application/json')
 
     fetch(`${accountConfig.data.productSearchUrl}v5/products/info?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`, requestOptions)
       .then(res => res.json())

--- a/src/api/getWebSettingsRequest.ts
+++ b/src/api/getWebSettingsRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, WebSettingsType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 // Importamos constantes
 import { DEGIRO_API_PATHS } from '../enums'
@@ -11,21 +11,7 @@ const { GET_WEB_SETTINGS_PATH } = DEGIRO_API_PATHS
 export function getWebSettingsRequest(accountData: AccountDataType, accountConfig: AccountConfigType): Promise<WebSettingsType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.paUrl}${GET_WEB_SETTINGS_PATH}?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`

--- a/src/api/getWebUserSettingsRequest.ts
+++ b/src/api/getWebUserSettingsRequest.ts
@@ -2,7 +2,7 @@
 import { AccountConfigType, AccountDataType, WebUserSettingType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 // Importamos constantes
 import { DEGIRO_API_PATHS } from '../enums'
@@ -11,21 +11,7 @@ const { GET_WEB_USER_SETTINGS_PATH } = DEGIRO_API_PATHS
 export function getWebUserSettingsRequest(accountData: AccountDataType, accountConfig: AccountConfigType): Promise<WebUserSettingType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.paUrl}${GET_WEB_USER_SETTINGS_PATH}?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`

--- a/src/api/getWebi18nMessagesRequest.ts
+++ b/src/api/getWebi18nMessagesRequest.ts
@@ -2,26 +2,12 @@
 import { AccountConfigType, AccountDataType, i18nMessagesType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function getWebi18nMessagesRequest(lang: string, accountData: AccountDataType, accountConfig: AccountConfigType): Promise<i18nMessagesType> {
   return new Promise((resolve, reject) => {
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      headers: {
-        Cookie: `JSESSIONID=${accountConfig.data.sessionId};`,
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
 
     // Do the request to get a account config data
     const uri = `${accountConfig.data.i18nUrl}messages_${lang}`

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -6,7 +6,7 @@ import { DEGIRO_API_PATHS } from '../enums'
 const { BASE_API_URL, LOGIN_URL_PATH } = DEGIRO_API_PATHS
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function loginRequest(params: LoginRequestParamsType): Promise<LoginResponseType> {
   return new Promise((resolve, reject) => {
@@ -23,28 +23,13 @@ export function loginRequest(params: LoginRequestParamsType): Promise<LoginRespo
       },
     }
 
-    const requestOptions: {
-      method?: string,
-      body?: string,
-      headers: {
-        [key: string]: string,
-      },
-      credentials: 'include',
-      referer: string,
-    } = {
-      method: 'POST',
-      body: JSON.stringify(payload),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-      referer: 'https://trader.degiro.nl/trader/',
-    }
+    const requestOptions = getFetchRequestOptions(undefined, 'POST', JSON.stringify(payload), 'application/json')
 
     // Do the request to get a session
-    debug(`Making request to ${BASE_API_URL}${LOGIN_URL_PATH} with options:`)
+    const uri = `${BASE_API_URL}${LOGIN_URL_PATH}`
+    debug(`Making request to ${uri} with options:`)
     debug(JSON.stringify(requestOptions, null, 2))
-    fetch(`${BASE_API_URL}${LOGIN_URL_PATH}`, requestOptions)
+    fetch(uri, requestOptions)
       .then((res) => {
         if (!payload.oneTimePassword) return res
         debug('Sending OTP')

--- a/src/api/logout.ts
+++ b/src/api/logout.ts
@@ -6,15 +6,16 @@ import { DEGIRO_API_PATHS } from '../enums'
 const { BASE_API_URL, LOGOUT_URL_PATH } = DEGIRO_API_PATHS
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 export function logoutRequest(accountData: AccountDataType, accountConfig: AccountConfigType): Promise<void> {
   return new Promise((resolve, reject) => {
 
     // Do the request to get a session
+    const requestOptions = getFetchRequestOptions(accountConfig.data.sessionId)
     const url = `${BASE_API_URL}${LOGOUT_URL_PATH};jsessionid=${accountConfig.data.sessionId}?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}`
     debug(`Making request to ${url}`)
-    fetch(url)
+    fetch(url, requestOptions)
       .then((res) => {
         if (res.status === 200) resolve()
         else reject(res.statusText || res.body)

--- a/src/api/searchProductRequest.ts
+++ b/src/api/searchProductRequest.ts
@@ -2,7 +2,7 @@
 import { SearchProductOptionsType, AccountConfigType, AccountDataType, SearchProductResultType } from '../types'
 
 // Import debug console log
-import { debug } from '../utils'
+import { debug, getFetchRequestOptions } from '../utils'
 
 const createURLQuery = (options: SearchProductOptionsType): string => {
   // Destructure the options parameter
@@ -25,9 +25,12 @@ export function searchProductRequest(options: SearchProductOptionsType, accountD
     // Preparae de request
     const params = createURLQuery(options)
 
+    const requestOptions = getFetchRequestOptions()
+
     // Do de request
-    debug(`Making a search request to url: ${accountConfig.data.productSearchUrl}v5/products/lookup?intAccount=${accountData.data.intAccount}&sessionId=${accountData.data.id}&${params}}`)
-    fetch(`${accountConfig.data.productSearchUrl}v5/products/lookup?intAccount=${accountData.data.intAccount}&sessionId=${accountConfig.data.sessionId}&${params}`)
+    const uri = `${accountConfig.data.productSearchUrl}v5/products/lookup?intAccount=${accountData.data.intAccount}&sessionId=${accountData.data.id}&${params}`
+    debug(`Making a search request to url: ${uri}`)
+    fetch(uri, requestOptions)
       .then(res => res.json())
       .then(({ products }) => resolve(products))
       .catch(reject)

--- a/src/enums/DeGiroEnums.ts
+++ b/src/enums/DeGiroEnums.ts
@@ -14,6 +14,7 @@ export enum DEGIRO_API_PATHS {
   GET_WEB_USER_SETTINGS_PATH = 'settings/user',
   GET_ACCOUNT_REPORTS_PATH = 'document/list/report',
   STOCKS_SEARCH_PATH = 'v5/stocks',
+  REFERER_ENDPOINT = 'trader/',
 }
 
 export enum DeGiroActions {

--- a/src/utils/getFetchRequestOptions.ts
+++ b/src/utils/getFetchRequestOptions.ts
@@ -1,0 +1,24 @@
+import { DEGIRO_API_PATHS } from '../enums'
+const { BASE_API_URL, REFERER_ENDPOINT } = DEGIRO_API_PATHS
+
+export function getFetchRequestOptions(sessionId?: string, method?: string, body?: string, contentType?: string): any {
+  const requestOptions: {
+    method?: string,
+    body?: string,
+    headers: {
+      [key: string]: string,
+    },
+    credentials: 'include',
+    referer: string,
+  } = {
+    ...(method && {method}),
+    headers: {
+      ...(sessionId && {Cookie: `JSESSIONID=${sessionId};`}),
+      ...(contentType && {'Content-Type': contentType}),
+    },
+    ...(body && {body}),
+    credentials: 'include',
+    referer: BASE_API_URL + REFERER_ENDPOINT,
+  }
+  return requestOptions
+}

--- a/src/utils/getFetchRequestOptions.ts
+++ b/src/utils/getFetchRequestOptions.ts
@@ -11,12 +11,12 @@ export function getFetchRequestOptions(sessionId?: string, method?: string, body
     credentials: 'include',
     referer: string,
   } = {
-    ...(method && {method}),
+    ...(method && { method }),
     headers: {
-      ...(sessionId && {Cookie: `JSESSIONID=${sessionId};`}),
-      ...(contentType && {'Content-Type': contentType}),
+      ...(sessionId && { Cookie: `JSESSIONID=${sessionId};` }),
+      ...(contentType && { 'Content-Type': contentType }),
     },
-    ...(body && {body}),
+    ...(body && { body }),
     credentials: 'include',
     referer: BASE_API_URL + REFERER_ENDPOINT,
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,10 +2,12 @@ import { debug } from './debug'
 import { processPortfolio } from './processPortfolio'
 import { processGetCashFundsResultListObject } from './processGetCashFundsResultListObject'
 import { processGetOrdersResultListObject } from './processGetOrdersResultListObject'
+import { getFetchRequestOptions } from './getFetchRequestOptions'
 
 export {
   debug,
   processPortfolio,
   processGetCashFundsResultListObject,
   processGetOrdersResultListObject,
+  getFetchRequestOptions,
 }


### PR DESCRIPTION
**WARNING**: This touches quite a bit of code, and I didn't run the test set with my account.

The reason for doing this is to control all fetch requestsOptions from a single point. This improves maintainability and legibility of the code. For me personally, I want to be able to control header information like user-agent and referrer.

Functions I did test: login, getAccountConfig, getAccoundData, getPortfolioRequest.

This is my first time coding in TypeScript, so any remarks are welcome!

Cheers!
